### PR TITLE
Catch more formats for a2a skills registration

### DIFF
--- a/src/core/endpoint-crawler.ts
+++ b/src/core/endpoint-crawler.ts
@@ -270,38 +270,13 @@ export class EndpointCrawler {
    *
    * Per A2A Protocol spec (v0.3.0), agent cards should have:
    *   skills: AgentSkill[] where each AgentSkill has a tags[] array
-   *
-   * This method also handles non-standard formats for backward compatibility:
-   * - detailedSkills[].tags[] (custom extension)
-   * - skills: ["tag1", "tag2"] (non-compliant flat array)
    */
   private _extractA2aSkills(data: any): string[] {
     const result: string[] = [];
 
-    // Try spec-compliant format first: skills[].tags[]
+    // Extract tags from skills array
     if ('skills' in data && Array.isArray(data.skills)) {
       for (const skill of data.skills) {
-        if (skill && typeof skill === 'object' && 'tags' in skill) {
-          // Spec-compliant: AgentSkill object with tags
-          const tags = skill.tags;
-          if (Array.isArray(tags)) {
-            for (const tag of tags) {
-              if (typeof tag === 'string') {
-                result.push(tag);
-              }
-            }
-          }
-        } else if (typeof skill === 'string') {
-          // Non-compliant: flat string array (fallback)
-          result.push(skill);
-        }
-      }
-    }
-
-    // Fallback to detailedSkills if no tags found in skills
-    // (custom extension used by some implementations)
-    if (result.length === 0 && 'detailedSkills' in data && Array.isArray(data.detailedSkills)) {
-      for (const skill of data.detailedSkills) {
         if (skill && typeof skill === 'object' && 'tags' in skill) {
           const tags = skill.tags;
           if (Array.isArray(tags)) {

--- a/tests/a2a-skills-extraction.test.ts
+++ b/tests/a2a-skills-extraction.test.ts
@@ -49,29 +49,14 @@ describe('A2A Skills Extraction', () => {
     expect(skills).toEqual(['blockchain', 'cryptocurrency', 'defi', 'trading']);
   });
 
-  test('should handle flat string array (non-compliant fallback)', async () => {
+  test('should return empty array for non-object skills', async () => {
     const mockAgentCard = {
-      skills: ['blockchain', 'cryptocurrency', 'defi'],
+      skills: ['blockchain', 'cryptocurrency', 'defi'], // Invalid format
     };
 
     const skills = (crawler as any)._extractA2aSkills(mockAgentCard);
 
-    expect(skills).toEqual(['blockchain', 'cryptocurrency', 'defi']);
-  });
-
-  test('should handle detailedSkills fallback', async () => {
-    const mockAgentCard = {
-      detailedSkills: [
-        {
-          id: 'skill-1',
-          tags: ['blockchain', 'cryptocurrency'],
-        },
-      ],
-    };
-
-    const skills = (crawler as any)._extractA2aSkills(mockAgentCard);
-
-    expect(skills).toEqual(['blockchain', 'cryptocurrency']);
+    expect(skills).toEqual([]);
   });
 
   test('should remove duplicate tags', async () => {
@@ -104,16 +89,19 @@ describe('A2A Skills Extraction', () => {
     expect(skills).toEqual([]);
   });
 
-  test('should handle mixed skill formats', async () => {
+  test('should skip skills without tags field', async () => {
     const mockAgentCard = {
       skills: [
         {
           id: 'skill-1',
           tags: ['blockchain'],
         },
-        'cryptocurrency', // flat string
         {
           id: 'skill-2',
+          name: 'No tags here', // Missing tags field
+        },
+        {
+          id: 'skill-3',
           tags: ['defi'],
         },
       ],
@@ -121,7 +109,7 @@ describe('A2A Skills Extraction', () => {
 
     const skills = (crawler as any)._extractA2aSkills(mockAgentCard);
 
-    expect(skills).toEqual(['blockchain', 'cryptocurrency', 'defi']);
+    expect(skills).toEqual(['blockchain', 'defi']);
   });
 
   test('should fetch skills from real Deep42 agent card', async () => {


### PR DESCRIPTION
Applies the same adjustment as python library: https://github.com/agent0lab/agent0-py/pull/4